### PR TITLE
Update the workshop training to use maker night and slack for inductions

### DIFF
--- a/rooms/workshop/training.md
+++ b/rooms/workshop/training.md
@@ -8,30 +8,7 @@ nav_order: 1
 
 # Workshop Induction
 
-The workshop induction program is there to ensure a new users can use the [Workshop Equipment](equipment.md) safely and effectively.
-
-The majority of advanced manufacturing equipment was paid for by the dues of fellow members, and some of that equipment can be dangerous if misused or neglected, so should be treated with respect and care.
-
-This induction is currently free of charge and is provided on a voluntary basis fortnightly.
-
-## Who can be inducted to use the workshop?
-
-* Farset Labs Members
-* Guests of a Named Farset Labs Member
-
-## Who can induct people into the use of the Workshop
-
-* Currently [Trained](trained.md) Farset Labs Members
-
-(Guests cannot induct others)
-
-## How to book an induction
-
-Inductions happen on a fortnightly basis.
-
-:calendar:[Book an appointment here.](https://calendar.google.com/calendar/u/0/selfsched?sstoken=UUw1ZG5SQmk3NlNlfGRlZmF1bHR8OWFhMTM0M2FiNDlkMjEwMmJjOTQ5YmQ3ZTA1MWFlNzk)
-
-'Exceptional' inductions can be arranged on a case by case basis by [trained](trained.md) individuals who are current members of Farset Labs.
+Please [attend the next Maker Night](https://www.farsetlabs.org.uk/events/makernight) or [say hello in the #workshop channel on Slack](https://www.farsetlabs.org.uk/slack) to get inducted on how to use the workshop equipment.
 
 # General Workshop Guidance
 
@@ -40,7 +17,7 @@ Inductions happen on a fortnightly basis.
   * Passive-aggressively shaming prior users is optional... but keep calm and [AGF](https://en.wikipedia.org/wiki/Wikipedia:Assume_good_faith)
 * Put any tools/equipment back where they belong
   * Not all tools have an obvious place where they should live, in which case, leave them back where you found them
-  * If you think there is a better place to put a particular tool, or a better way to arrange things, discuss it in the #facilities room on [Slack](https://farsetlabs.slack.com)
+  * If you think there is a better place to put a particular tool, or a better way to arrange things, discuss it in the [#workshop channel on Slack](https://www.farsetlabs.org.uk/slack)
 * Do not enter the workshop while under the influence of alcohol, recreational drugs, or medication that may impair your ability to work safely
 * If someone else is working in the workshop, ask if your planned work would impair their current work (first come first serve principle)
 
@@ -61,7 +38,7 @@ Inductions happen on a fortnightly basis.
 
 
 
-The GlowForge Pro is a Class 4 laser product, emitting enough infrared light to cause instant skin and eye injury, or start a fire. 
+The GlowForge Pro is a Class 4 laser product, emitting enough infrared light to cause instant skin and eye injury, or start a fire.
 
 This infrared light is invisible.
 
@@ -69,11 +46,11 @@ The Unit has a case and glass lid that block harmful levels of infrared and UV l
 
 **If there appears to be any damage to the glass or the case, do not use the laser cutter and notify the management team immediately**
 
-Safety interlock switches on the front door will turn off the laser immediately if the lid is opened. 
+Safety interlock switches on the front door will turn off the laser immediately if the lid is opened.
 
 ## The Context
 
-The [GlowForge](https://glowforge.com/our-products/pro) was half-funded by the [Halifax Foundation](https://www.halifaxfoundationni.org/programmes/community-grant-programme) under their Community Grants programme, where £4000 of the £7000 necessary funding required to get the laser cutter. The remainder was made up from general charity funds for the following purposes: 
+The [GlowForge](https://glowforge.com/our-products/pro) was half-funded by the [Halifax Foundation](https://www.halifaxfoundationni.org/programmes/community-grant-programme) under their Community Grants programme, where £4000 of the £7000 necessary funding required to get the laser cutter. The remainder was made up from general charity funds for the following purposes:
 
 * Provide Laser Cutting Facility available to the community
 * Generate and Deliver Education and Safety Training to at least 50 individuals in the local community in 2020/2021 (Including CoderDojo-suitable activities)
@@ -83,7 +60,7 @@ The initially stated measure of success of the grant were:
 
 * Total Hours of Operation
 * Total External Booking Hours
-* Number of Inducted Persons 
+* Number of Inducted Persons
 * Number of Published Build-Guides
 
 The inline power monitor ([ESPURNA-B60BBA](https://grafana.farsetlabs.org.uk/d/pBIm9WzGz/power-monitoring?orgId=1)) is used to monitor the usage of the laser cutter. It is in the 'fixed-on' configuration so power should be switched from the rear of the laser-cutter.
@@ -91,7 +68,7 @@ The inline power monitor ([ESPURNA-B60BBA](https://grafana.farsetlabs.org.uk/d/p
 ## The Rules
 
 * **Do not** leave the laser cutter unattended when in operation
-  * Most cuts are relatively fast anyway (<30min for A4 engraving) 
+  * Most cuts are relatively fast anyway (<30min for A4 engraving)
 * **Do not** put **any** material in the laser cutter bed that you are not **positive** is [laser safe](laser_cutter_materials.md)
 * **Do not** touch the head or arm of the laser cutter while the power is on; if you do by accident, restart the unit to prevent possible damage
 * **Do not** attempt to service, repair, modify, 'improve' or dismantle the unit
@@ -125,13 +102,13 @@ As previously stated, **do not use non-approved materials in the laser**.
   * The crumb tray can be removed to expand this to 50mm (2 in.), but should be avoided...
 * Materials must be flat so they rest on the crumb tray with a flat upper surface
 
-## Design Resources: 
+## Design Resources:
 
 ### [Boxes.py](https://www.festi.info/boxes.py/index.html)
 
 >        [Boxes.py](https://hackaday.io/project/10649-boxespy) is an [Open Source](https://www.gnu.org/licenses/gpl-3.0.en.html) box generator written in [Python](https://www.python.org/). It features both finished parametrized generators as well as a Python  API for writing your own. It features finger and (flat) dovetail joints, flex cuts, holes and slots for screws, hinges, gears, pulleys and much  more.
 
-#### **Gotchas:** 
+#### **Gotchas:**
 
 The default burn rate is too wide for the glowforge: **set it to 0.06**
 
@@ -158,7 +135,7 @@ Induction is certified by completing the following tasks (under supervision)
 
 ## The Context
 
-Farset has had 3D printing facilities for a long time, and many members are familiar with their operation (our first printer, an Ultimaker, currently lives broken and beaten upstairs in the lounge after some overly optimistic modifications...). 
+Farset has had 3D printing facilities for a long time, and many members are familiar with their operation (our first printer, an Ultimaker, currently lives broken and beaten upstairs in the lounge after some overly optimistic modifications...).
 
 Over the years, the safety of 3D printing has been greatly improved and is much simpler from an operational perspective (but riskier from a design perspective; outside of the scope of this induction).
 
@@ -166,11 +143,11 @@ However, much of the performance of 3D printing is almost always dependent on th
 
 ### Lulzbot Mini
 
-The [Lulzbot mini](https://www.lulzbot.com/store/printers/lulzbot-mini) (to the left in the above image) is the simpler, newer and faster of the two printers. 
+The [Lulzbot mini](https://www.lulzbot.com/store/printers/lulzbot-mini) (to the left in the above image) is the simpler, newer and faster of the two printers.
 
 It was subsidised as part of a [UK Hackspace Foundation](https://forum.hackspace.org.uk/t/lulzbot-3d-printers-giveaway/220/33) programme and arrived during the 2019 [renovation](https://blog.farsetlabs.org.uk/2019/06/farset-labs-v2-expanding-renovating-improving/) period.
 
-Before it could be 'officially' unveiled, COVID hit in 2020 and it was put to much more valuable work at the time [with Axial3D](https://twitter.com/FarsetLabs/status/1246124950282481666) 
+Before it could be 'officially' unveiled, COVID hit in 2020 and it was put to much more valuable work at the time [with Axial3D](https://twitter.com/FarsetLabs/status/1246124950282481666)
 
 **This printer is kept as our 'gold disk' untouched 3D printer and should not be modified in any circumstances**
 
@@ -178,7 +155,7 @@ Before it could be 'officially' unveiled, COVID hit in 2020 and it was put to mu
 
 The [Anet A8](https://all3dp.com/1/anet-a8-3d-printer-review-diy-kit/) is a much simpler beast, and was purchased by a member and then donated to the charity in mid 2018.
 
-It is operated via an [OctoPrint](https://octoprint.org/) server hosted on a Raspberry Pi sitting beside it. 
+It is operated via an [OctoPrint](https://octoprint.org/) server hosted on a Raspberry Pi sitting beside it.
 
 It's accessible onsite from [http://octopi.local](http://octopi.local) with the credentials `user:`:`clubmate`
 
@@ -192,7 +169,7 @@ This printer can be made available for more experimental modifications as long a
 
 _This induction only deals with the use of the Lulzbot Mini, as the level of experience necessary to use the Anet A8 is best gained practically_
 
-Using the PC connected to the printer, launch the [Cura](https://www.lulzbot.com/cura) application. 
+Using the PC connected to the printer, launch the [Cura](https://www.lulzbot.com/cura) application.
 
 This application is a '[slicer](https://en.wikipedia.org/wiki/Slicer_(3D_printing))', which can take pre-made 3D model files and, with a wide range of settings, calculates a 'tool path', i.e. the physical motions of the 3D printer extruder nozzle with respect to the heated bed to build up your model.
 
@@ -210,7 +187,7 @@ Changing filament requires the following steps, regardless of which printer you'
 
 * **Avoid** leaving the 3D printer unattended when in operation
   * For long 3D prints (on the order of hours), do not leave the building, check in on the print at least once every 15 minutes, and preferably, work from the event space if you want to leave the workshop
-* **Do not** leave the 3D printer unattended at the start of a print 
+* **Do not** leave the 3D printer unattended at the start of a print
   * Most mistakes/failures happen or are evident in the first 5-10 layers of a print
 * **Do not** touch the print bed or the print head during a print.
   * **Really**; some parts are very hot, and even if you avoid those, you can ruin your print...
@@ -220,7 +197,7 @@ Changing filament requires the following steps, regardless of which printer you'
   * **If the part cannot be removed from the bed:**
     * Try prising one corner/side away from the bed using a flat blade like a pallet knife, chisel or similar, and then progressively shimming under the part. It should 'pop' off...
     * If that isn't working, you may need to apply more force with a hammer or mallet; **do not** hammer the part or the build plate directly, always use a shim as above.
-    * If that isn't working, raise the bed temperature to between 60ºC and 80ºC. Once the bed is up to temperature, try prising under it again. 
+    * If that isn't working, raise the bed temperature to between 60ºC and 80ºC. Once the bed is up to temperature, try prising under it again.
     * If **that** isn't working, try a short burst of canned air directly on the most 'accessible' edge of the part to try and use thermal contraction to 'pop' the piece.
   * If you've tried all of that and you're still stuck; ask for help. Don't leave the piece silently for someone else to deal with; raise it in #facilities and if you have to leave, leave a note.
 * **Always** ensure the printer is turned off when not in use.


### PR DESCRIPTION
Context: someone turned up for an induction after booking through the calendar. We don’t currently support this / have visibility into this.

Instead, let’s point folks to the slack channel and to the maker night as a way to sort out workshop inductions.